### PR TITLE
Resolved Null subtype error of RenderBox

### DIFF
--- a/lib/src/nodes.dart
+++ b/lib/src/nodes.dart
@@ -232,15 +232,26 @@ class NodesManager {
     }
   }
 
-  Size getNodeWidgetSize(String nodeName) {
-    GlobalKey? key = nodes[nodeName]?.globalKey;
-
-    if (key == null) {
-      throw Exception('node: $nodeName not found');
-    }
-
-    final RenderBox renderBox =
-        key.currentContext?.findRenderObject() as RenderBox;
-    return renderBox.size;
+Size getNodeWidgetSize(String nodeName) {
+  NodeModel? nodeModel = nodes[nodeName];
+  if (nodeModel == null) {
+    throw Exception('node: $nodeName not found');
   }
+
+  final GlobalKey? key = nodeModel.globalKey;
+  if (key == null) {
+    return Size.zero;
+  }
+
+  Size size = Size.zero;
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    final RenderBox? renderBox =
+        key.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox != null) {
+      size = renderBox.size;
+    }
+  });
+
+  return size;
+}
 }


### PR DESCRIPTION
#1 This PR modifies the getNodeWidgetSize function to ensure that the RenderBox of the NodeEditor widget is properly laid out and rendered before attempting to access its size. The function first checks if the NodeModel and its associated GlobalKey exist. If the GlobalKey is not null, the code that retrieves the RenderBox is deferred until after the current frame has been rendered using WidgetsBinding.instance.addPostFrameCallback. Inside the callback function, the RenderBox is retrieved from the GlobalKey, and its size is assigned to the size variable. If the RenderBox is null, the size variable is set to Size.zero. By deferring the execution of the code that accesses the RenderBox until after the current frame has been rendered, the function ensures that the NodeEditor widget has been properly laid out, resolving the type 'Null' is not a subtype of type 'RenderBox' error.